### PR TITLE
Respect TRACE and SHOW_SIZE flags during construction and destruction

### DIFF
--- a/RMQRMM64.cpp
+++ b/RMQRMM64.cpp
@@ -519,9 +519,10 @@ void RMQRMM64::createMinMaxTree(){
 	}else
 		lgBkM=sizeDS=0;
 
-	if (TRACE || SHOW_SIZE)
+	if (TRACE || SHOW_SIZE){
 		cout << " ** size of BkM[] " << sizeDS << " Bytes" << endl;
-	cout << " ** Total RMQRMM64 size: " << sizeRMM << " Bytes = " << (float)sizeRMM/(1024.0*1024.0) << " MB." << endl;
+		cout << " ** Total RMQRMM64 size: " << sizeRMM << " Bytes = " << (float)sizeRMM/(1024.0*1024.0) << " MB." << endl;
+	}
 	
 	if (TRACE){
 		cout << "MIN_BCK " << MIN_BCK << ", lgBkM " << lgBkM << endl;
@@ -1740,5 +1741,5 @@ RMQRMM64::~RMQRMM64() {
 	if(lenSS) delete [] TSS;
 	if(nBLK) delete [] TMinB;
 
-	cout << " ~ RMQRMM64 destroyed !!" << endl;
+	if(TRACE) cout << " ~ RMQRMM64 destroyed !!" << endl;
 }


### PR DESCRIPTION
Despite the `TRACE` and `SHOW_SIZE` flags being off by default, the construction and destruction would cause related messages to be printed to the standard output. This commit makes them respect the flags and print nothing by default.